### PR TITLE
Implements `track`

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -61,28 +61,30 @@ describe(@"SEGAdobeIntegration", ^{
         });
     });
     describe(@"track", ^{
-        it(@"it tracks a custom event without properties", ^{
-            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{} context:@{} integrations:@{}];
-            [integration track:trackPayload];
-            [verify(mockADBMobile) trackAction:@"Testing" data:nil];
-        });
-        it(@"it tracks a custom event with properties NOT configured in settings.contextValues", ^{
-            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{ @"plan" : @"self-service" } context:@{} integrations:@{}];
-            [integration track:trackPayload];
-            [verify(mockADBMobile) trackAction:@"Testing" data:nil];
-        });
-        it(@"it tracks a custom event with properties configured in settings.contextValues", ^{
+        it(@"tracks an action without properties but with settings.contextValues", ^{
             integration = [[SEGAdobeIntegration alloc] initWithSettings:@{ @"contextValues" : @{
                 @"plan" : @"myapp.plan",
                 @"subscribed" : @"myapp.subscribed"
             } } andADBMobile:mockADBMobile];
-            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{ @"plan" : @"self-service",
-                                                                                                            @"subscribed" : @YES }
+            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{} context:@{} integrations:@{}];
+            [integration track:trackPayload];
+            [verify(mockADBMobile) trackAction:@"Testing" data:nil];
+        });
+        it(@"tracks an action with properties NOT configured in settings.contextValues", ^{
+            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{ @"plan" : @"self-service" } context:@{} integrations:@{}];
+            [integration track:trackPayload];
+            [verify(mockADBMobile) trackAction:@"Testing" data:nil];
+        });
+        it(@"tracks an action with some properties configured in settings.contextValues", ^{
+            integration = [[SEGAdobeIntegration alloc] initWithSettings:@{ @"contextValues" : @{
+                @"plan" : @"myapp.plan",
+                @"subscribed" : @"myapp.subscribed"
+            } } andADBMobile:mockADBMobile];
+            SEGTrackPayload *trackPayload = [[SEGTrackPayload alloc] initWithEvent:@"Testing" properties:@{ @"plan" : @"self-service" }
                 context:@{}
                 integrations:@{}];
             [integration track:trackPayload];
-            [verify(mockADBMobile) trackAction:@"Testing" data:@{ @"myapp.plan" : @"self-service",
-                                                                  @"myapp.subscribed" : @YES }];
+            [verify(mockADBMobile) trackAction:@"Testing" data:@{ @"myapp.plan" : @"self-service" }];
         });
     });
 });

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -71,7 +71,9 @@
         NSMutableDictionary *data = [[NSMutableDictionary alloc] initWithCapacity:contextValuesSize];
         NSDictionary *contextValues = self.settings[@"contextValues"];
         for (NSString *key in contextValues) {
-            [data setObject:properties[key] forKey:contextValues[key]];
+            if (properties[key]) {
+                [data setObject:properties[key] forKey:contextValues[key]];
+            }
         }
         return data;
     }


### PR DESCRIPTION
Adobe requires users to configure all custom variables, known as `eVars` or `Props`, in their UI.
The technical value for props and eVars are called [`contextData`](https://www.dropbox.com/s/g0wj1x24qt8962k/Screenshot%202017-11-14%2016.43.39.png?dl=0).

Adobe has a very specific namespace, ex `myapp.property`, for this `contextData`. For this reason, Segment has a setting `contextValues` which allows users to configure which Segment properties to map to specific Adobe variables. Segment will only send properties if they are present in `settings.contextValues` since Adobe does not populate their UI with non-configured variables.