### PR TITLE
 [STRATCONN-90] Fix Bundling Issue with Transitive Dependency

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - OCHamcrest (7.0.2)
   - OCMockito (5.0.1):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.1.1-beta):
+  - Segment-Adobe-Analytics (1.2.0):
     - AdobeMobileSDK
     - AdobeVideoHeartbeatSDK
     - Analytics (~> 3.5)
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - Specta
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - AdobeMobileSDK
     - AdobeVideoHeartbeatSDK
     - Analytics
@@ -44,9 +44,9 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: 706bfbf69a3df55a873bad096014e80e2e8ca93c
   OCMockito: 063837a086c058e764fcd23e771089c1759e7197
-  Segment-Adobe-Analytics: ab208b11a989fe3ac29d0da3a2a801e75c6ac3ce
+  Segment-Adobe-Analytics: c937639a0fc97cf5d4d12c357268c2560b39bb38
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 7a306446e2a5328d23dcbfe74027397be19f3633
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -7,7 +7,8 @@
 //
 
 // https://github.com/Specta/Specta
-
+#import "ADBMediaHeartbeatConfig.h"
+#import "ADBMediaHeartbeat.h"
 
 @interface SEGMockADBMediaHeartbeatFactory : NSObject <SEGADBMediaHeartbeatFactory>
 @property (nonatomic, strong) ADBMediaHeartbeat *mediaHeartbeat;

--- a/Pod/Classes/SEGAdobeIntegration.h
+++ b/Pod/Classes/SEGAdobeIntegration.h
@@ -9,8 +9,10 @@
 #import <Foundation/Foundation.h>
 #import <Analytics/SEGIntegration.h>
 #import <AdobeMobileSDK/ADBMobile.h>
-#import "ADBMediaHeartbeat.h"
-#import "ADBMediaHeartbeatConfig.h"
+
+@class ADBMediaHeartbeat;
+@class ADBMediaObject;
+@class ADBMediaHeartbeatConfig;
 
 @protocol SEGADBMediaHeartbeatFactory <NSObject>
 - (ADBMediaHeartbeat *_Nullable)createWithDelegate:(id _Nullable)delegate andConfig:(ADBMediaHeartbeatConfig *_Nonnull)config;
@@ -29,7 +31,7 @@
 @end
 
 
-@interface SEGPlaybackDelegate : NSObject <ADBMediaHeartbeatDelegate>
+@interface SEGPlaybackDelegate : NSObject
 /**
  * Quality of service object. This is created and updated upon receipt of a "Video Quality
  * Updated" event, which triggers createAndUpdateQosObject(Properties).

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -11,7 +11,10 @@
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGAnalytics.h>
 #import "ADBMediaHeartbeat.h"
+#import "ADBMediaHeartbeatConfig.h"
 
+@interface SEGPlaybackDelegate(Private)<ADBMediaHeartbeatDelegate>
+@end
 
 @implementation SEGPlaybackDelegate
 
@@ -26,7 +29,7 @@
 
 /**
  Adobe invokes this method once per second to resolve the current position of the videoplayhead. Unless paused, this method increments the value of playheadPosition by one every second by calling incrementPlayheadPosition
- 
+
  @return playheadPosition
  */
 - (NSTimeInterval)getCurrentPlaybackTime
@@ -72,12 +75,12 @@
 
 /**
  Internal helper function used to calculate the playheadPosition.
- 
+
  CFAbsoluteTimeGetCurrent retrieves the current time in seconds,
  then we calculate the delta between the CFAbsoluteTimeGetCurrent time
  and the playheadPositionTime, which is the CFAbsoluteTimeGetCurrent
  at the time a Segment Spec'd Video event is triggered.
- 
+
  @return Updated playheadPosition
  */
 - (long)calculateCurrentPlayheadPosition

--- a/Pod/Classes/SEGAdobeIntegrationFactory.m
+++ b/Pod/Classes/SEGAdobeIntegrationFactory.m
@@ -1,5 +1,6 @@
 #import "SEGAdobeIntegrationFactory.h"
 #import "SEGAdobeIntegration.h"
+#import "ADBMediaHeartbeatConfig.h"
 
 
 @implementation SEGAdobeIntegrationFactory

--- a/Segment-Adobe-Analytics.podspec
+++ b/Segment-Adobe-Analytics.podspec
@@ -21,4 +21,7 @@ Pod::Spec.new do |s|
   s.dependency 'Analytics', '~> 3.5'
   s.dependency 'AdobeMobileSDK'
   s.dependency 'AdobeVideoHeartbeatSDK'
+
+  s.static_framework = true
+  s.module_name      = 'Segment_Adobe_Analytics'
 end


### PR DESCRIPTION
There are issues with this pod for customers who use `use_frameworks!` to build their apps because of a transitive dependency from Adobe that has a static library instead of a framework. This has caused customers errors such as "target has transitive dependencies that include statically linked binaries” when installing the pod. This is largely and issue for customers implementing with Swift apps which prefers dynamic libraries, and the current Segment Adobe Analytics SDK requires the entire environment n which it is included (ie. all pods) to be static. For some customers their other pods are built as dynamic  libraries so usage of our statically linked library is disallowed and causes build errors. 

To fix this: 
1. Add `s.static-framework = true`
2. Move the imports of `ADBMediaHeartbeat.h` and `ADBMediaHeartbeatConfig.h`into the `.m` file and declare the imports using a forward declaration with `@class` in the header fi.e. 
3. Fix unit tests 

Goal: Run `pod lib lint` without any errors and without `--use-libraries` flag without errors.

JIRA: https://segment.atlassian.net/browse/STRATCONN-90 