### PR TITLE
[STRATCONN-120] Fix Crash when Publisher not sent in Properties 

### DIFF
--- a/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
+++ b/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
@@ -7,12 +7,28 @@
 //
 
 #import "SEGAdobeAppDelegate.h"
+#import "SEGAdobeIntegrationFactory.h"
+#import <Analytics/SEGAnalytics.h>
+
 
 
 @implementation SEGAdobeAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
+
+  [config use:[SEGAdobeIntegrationFactory instance]];
+  [SEGAnalytics setupWithConfiguration:config];
+  [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+  [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
+                         properties: @{ @"full_episode": @true }
+                            options: @{
+                              @"integrations": @{}
+                          }];
+
+    [[SEGAnalytics sharedAnalytics] flush];
+    [SEGAnalytics debug:YES];
     // Override point for customization after application launch.
     return YES;
 }

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -770,7 +770,7 @@ describe(@"SEGAdobeIntegration", ^{
                 [verify(mockADBMediaHeartbeat) trackEvent:ADBMediaHeartbeatEventChapterStart mediaObject:mockADBMediaObject data:nil];
             });
 
-            it(@"track Video Content Started without Publishe", ^{
+            it(@"track Video Content Started without Publisher", ^{
                 SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
                 mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;
 

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -770,6 +770,34 @@ describe(@"SEGAdobeIntegration", ^{
                 [verify(mockADBMediaHeartbeat) trackEvent:ADBMediaHeartbeatEventChapterStart mediaObject:mockADBMediaObject data:nil];
             });
 
+            it(@"track Video Content Started without Publishe", ^{
+                SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
+                mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;
+
+                SEGMockADBMediaObjectFactory *mockADBMediaObjectFactory = [[SEGMockADBMediaObjectFactory alloc] init];
+                mockADBMediaObjectFactory.mediaObject = mockADBMediaObject;
+
+                SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Content Started" properties:@{
+                    @"asset_id" : @"3543",
+                    @"pod_id" : @"65462",
+                    @"title" : @"Big Trouble in Little Sanchez",
+                    @"season" : @"2",
+                    @"episode" : @"7",
+                    @"genre" : @"cartoon",
+                    @"program" : @"Rick and Morty",
+                    @"total_length" : @400,
+                    @"full_episode" : @YES,
+                    @"position" : @22,
+                    @"channel" : @"Cartoon Network",
+                    @"start_time" : @140,
+                    @"position" : @5
+                } context:@{}
+                    integrations:@{}];
+                [integration track:payload];
+                [verify(mockADBMediaHeartbeat) trackPlay];
+                [verify(mockADBMediaHeartbeat) trackEvent:ADBMediaHeartbeatEventChapterStart mediaObject:mockADBMediaObject data:nil];
+            });
+
             it(@"track Video Content Completed", ^{
                 SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
                 mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;
@@ -870,6 +898,29 @@ describe(@"SEGAdobeIntegration", ^{
                         @"total_length" : @110,
                         @"position" : @43,
                         @"publisher" : @"Adult Swim",
+                        @"title" : @"Rick and Morty Ad"
+                    }
+                    context:@{}
+                    integrations:@{}];
+
+                [integration track:payload];
+                [verify(mockADBMediaHeartbeat) trackEvent:ADBMediaHeartbeatEventAdStart mediaObject:mockADBMediaObject data:nil];
+            });
+
+            it(@"tracks Video Ad Started without Publisher", ^{
+                SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
+                mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;
+
+                SEGMockADBMediaObjectFactory *mockADBMediaObjectFactory = [[SEGMockADBMediaObjectFactory alloc] init];
+                mockADBMediaObjectFactory.mediaObject = mockADBMediaObject;
+
+                SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Ad Started"
+                    properties:@{
+                        @"asset_id" : @"1231312",
+                        @"pod_id" : @"43434234534",
+                        @"type" : @"mid-roll",
+                        @"total_length" : @110,
+                        @"position" : @43,
                         @"title" : @"Rick and Morty Ad"
                     }
                     context:@{}

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -726,9 +726,10 @@
 
     // Segment's paublisher property exists on the content and ad level. Adobe
     // needs to interpret this either as and Advertiser (ad events) or Originator (content events)
-    if ([eventType isEqualToString:@"Ad"] || [eventType isEqualToString:@"Ad Break"]) {
+    NSString *publisher = [properties valueForKey:@"publisher"];
+    if (([eventType isEqualToString:@"Ad"] || [eventType isEqualToString:@"Ad Break"]) && [publisher length]) {
         [standardVideoMetadata setObject:properties[@"publisher"] forKey:ADBAdMetadataKeyADVERTISER];
-    } else if ([eventType isEqualToString:@"Content"]) {
+    } else if ([eventType isEqualToString:@"Content"] && [publisher length]) {
         [standardVideoMetadata setObject:properties[@"publisher"] forKey:ADBVideoMetadataKeyORIGINATOR];
     }
 


### PR DESCRIPTION
A customer reported that their app is crashing when they are not passing `publisher`. It is because we are not checking if `properties[@”publisher”]` exists before trying to set the object for standard ad and content video data here: SEGAdobeIntegration.m#L727-L733 .

This PR checks to see if the property value is present before setting it on the Ad or Content Metadata object. It also adds a general App Configuration with AA to the `SEGAdobeAppDelegate` with an example payload on `didFinishLaunchingWithOptions`. This PR also added passing unit tests for Content and Ad events without a publisher property passed in the payload. 

JIRA: https://segment.atlassian.net/browse/STRATCONN-120