### PR TITLE
Fix build errors with Cocoapods generate_multiple_pod_projects

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -14,7 +14,7 @@ PODS:
   - OCHamcrest (7.0.2)
   - OCMockito (5.0.1):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.3.1):
+  - Segment-Adobe-Analytics (1.4.0):
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
     - AdobeVideoHeartbeatSDK
@@ -49,9 +49,9 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: 706bfbf69a3df55a873bad096014e80e2e8ca93c
   OCMockito: 063837a086c058e764fcd23e771089c1759e7197
-  Segment-Adobe-Analytics: af888a03c89b56522085d942c0fba8ee95a2b79a
+  Segment-Adobe-Analytics: f27d9a8dd939a52df366fc133f2934a5885c6ced
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1

--- a/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
+++ b/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0749C4DF59F3BA84EF7206C6 /* libPods-Segment-Adobe-Analytics_TVOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D3E321022149B475A362DA1 /* libPods-Segment-Adobe-Analytics_TVOS.a */; };
 		1A558AFA1D02C9374645EF30 /* libPods-Segment-Adobe-Analytics_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -65,6 +66,7 @@
 		0DFCA7C25AE551722E1AA9A0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		3339EE10D97DBF9AF8E1109F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4D3E321022149B475A362DA1 /* libPods-Segment-Adobe-Analytics_TVOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_TVOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		589428CB55A1F8A3818A9CF5 /* Segment-Adobe-Analytics.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Segment-Adobe-Analytics.podspec"; path = "../Segment-Adobe-Analytics.podspec"; sourceTree = "<group>"; };
 		5E5F710DF340B64E7CB3BB5D /* Pods-Segment-Adobe-Analytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_Tests/Pods-Segment-Adobe-Analytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6003F58A195388D20070C39A /* Segment-Adobe-Analytics_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Segment-Adobe-Analytics_Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -93,6 +95,8 @@
 		956FC58D1FB4D502003028A2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		956FC58F1FB4D50B003028A2 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
 		D7A0A51A9D07415B1B95EB09 /* Pods-Segment-Adobe-Analytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_Tests/Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		DBDA63FFBE4B93C8EC599244 /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_TVOS/Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig"; sourceTree = "<group>"; };
+		E4F8796965BD7884C0E377CA /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_TVOS/Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig"; sourceTree = "<group>"; };
 		EAEE78C4242934740071E702 /* Segment-Adobe-Analytics_TVOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Segment-Adobe-Analytics_TVOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EAEE78C6242934740071E702 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EAEE78C7242934740071E702 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -142,6 +146,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0749C4DF59F3BA84EF7206C6 /* libPods-Segment-Adobe-Analytics_TVOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +174,8 @@
 				F5AEDAB8513E5B93AFA4DBBB /* Pods-Segment-Adobe-Analytics_Example.release.xcconfig */,
 				5E5F710DF340B64E7CB3BB5D /* Pods-Segment-Adobe-Analytics_Tests.debug.xcconfig */,
 				D7A0A51A9D07415B1B95EB09 /* Pods-Segment-Adobe-Analytics_Tests.release.xcconfig */,
+				E4F8796965BD7884C0E377CA /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */,
+				DBDA63FFBE4B93C8EC599244 /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -214,6 +221,7 @@
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */,
 				03108D42F9B3F734F0E744D9 /* libPods-Segment-Adobe-Analytics_Tests.a */,
+				4D3E321022149B475A362DA1 /* libPods-Segment-Adobe-Analytics_TVOS.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -369,6 +377,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAEE78F3242934750071E702 /* Build configuration list for PBXNativeTarget "Segment-Adobe-Analytics_TVOS" */;
 			buildPhases = (
+				F38920416165222826979DAA /* [CP] Check Pods Manifest.lock */,
 				EAEE78C0242934740071E702 /* Sources */,
 				EAEE78C1242934740071E702 /* Frameworks */,
 				EAEE78C2242934740071E702 /* Resources */,
@@ -547,6 +556,28 @@
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Segment-Adobe-Analytics_Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F38920416165222826979DAA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Adobe-Analytics_TVOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -828,6 +859,7 @@
 		};
 		EAEE78ED242934750071E702 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4F8796965BD7884C0E377CA /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -866,6 +898,7 @@
 		};
 		EAEE78EE242934750071E702 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = DBDA63FFBE4B93C8EC599244 /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
+++ b/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
@@ -16,48 +16,20 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
-
-  [config use:[SEGAdobeIntegrationFactory instance]];
-  [SEGAnalytics setupWithConfiguration:config];
-  [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
-  [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
-                         properties: @{ @"full_episode": @true }
-                            options: @{
-                              @"integrations": @{}
-                          }];
-
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
+    
+    [config use:[SEGAdobeIntegrationFactory instance]];
+    [SEGAnalytics setupWithConfiguration:config];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
+                               properties: @{ @"full_episode": @true }
+                                  options: @{
+                                      @"integrations": @{}
+                                  }];
+    
     [[SEGAnalytics sharedAnalytics] flush];
     [SEGAnalytics debug:YES];
-    // Override point for customization after application launch.
     return YES;
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-}
-
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-}
-
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 }
 
 @end

--- a/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
+++ b/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
@@ -7,6 +7,8 @@
 //
 
 #import "AppDelegate.h"
+#import "SEGAdobeIntegrationFactory.h"
+#import <Analytics/SEGAnalytics.h>
 
 @interface AppDelegate ()
 
@@ -16,30 +18,20 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Override point for customization after application launch.
+    SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY_HERE"];
+    
+    [config use:[SEGAdobeIntegrationFactory instance]];
+    [SEGAnalytics setupWithConfiguration:config];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
+                               properties: @{ @"full_episode": @true }
+                                  options: @{
+                                      @"integrations": @{}
+                                  }];
+    
+    [[SEGAnalytics sharedAnalytics] flush];
+    [SEGAnalytics debug:YES];
     return YES;
 }
-
-
-- (void)applicationWillResignActive:(UIApplication *)application {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-}
-
-
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-}
-
-
-- (void)applicationWillEnterForeground:(UIApplication *)application {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-}
-
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
 
 @end

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 7"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
 PROJECT := Segment-Adobe-Analytics
 XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -10,8 +10,8 @@
 #import <Analytics/SEGIntegration.h>
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGAnalytics.h>
-#import "ADBMediaHeartbeat.h"
-#import "ADBMediaHeartbeatConfig.h"
+#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeat.h>
+#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeatConfig.h>
 
 @interface SEGPlaybackDelegate(Private)<ADBMediaHeartbeatDelegate>
 @end

--- a/Pod/Classes/SEGAdobeIntegrationFactory.m
+++ b/Pod/Classes/SEGAdobeIntegrationFactory.m
@@ -1,6 +1,6 @@
 #import "SEGAdobeIntegrationFactory.h"
 #import "SEGAdobeIntegration.h"
-#import "ADBMediaHeartbeatConfig.h"
+#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeatConfig.h>
 
 
 @implementation SEGAdobeIntegrationFactory


### PR DESCRIPTION
* Removes #imports quote syntax to fix build errors with Cocoapods (see https://github.com/CocoaPods/CocoaPods/issues/9274)
* Adds sample code to the tvOS example project.
* Updates unit tests to run on iPhone 11.
* Updates example app to use latest Cocoapods version 1.9.1
* Update example app to Segment-Adobe-Analytics 1.4.0


[sample-project-showing-build-error.zip](https://github.com/segment-integrations/analytics-ios-integration-adobe-analytics/files/4377849/sample-project-showing-build-error.zip)
