### PR TITLE
[STRATCONN-146] Upgrade Adobe Heartbeat SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           name: Install build dependencies
           command: |
             sudo gem install xcpretty
-            sudo gem install cocoapods -v 1.6.1
+            sudo gem install cocoapods -v 1.8.4
       - run:
           name: Fetch Cocoapods specs
           command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,24 +1,20 @@
 PODS:
+  - AdobeMediaSDK (2.2.7):
+    - AdobeMobileSDK
+    - AdobeMobileSDK/TVOS
   - AdobeMobileSDK (4.18.7):
     - AdobeMobileSDK/iOS (= 4.18.7)
   - AdobeMobileSDK/iOS (4.18.7)
   - AdobeMobileSDK/TVOS (4.19.1)
-  - AdobeVideoHeartbeatSDK (2.0.0):
-    - AdobeVideoHeartbeatSDK/iOS (= 2.0.0)
-  - AdobeVideoHeartbeatSDK/iOS (2.0.0):
-    - AdobeMobileSDK
-  - AdobeVideoHeartbeatSDK/TVOS (2.1):
-    - AdobeMobileSDK/TVOS
   - Analytics (3.6.7)
   - Expecta (1.0.6)
   - OCHamcrest (7.0.2)
   - OCMockito (5.0.1):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.4.0):
+  - Segment-Adobe-Analytics (1.4.3):
+    - AdobeMediaSDK
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
-    - AdobeVideoHeartbeatSDK
-    - AdobeVideoHeartbeatSDK/TVOS
     - Analytics (~> 3.5)
   - Specta (1.0.7)
 
@@ -31,25 +27,26 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AdobeMobileSDK
-    - AdobeVideoHeartbeatSDK
     - Analytics
     - Expecta
     - OCHamcrest
     - OCMockito
     - Specta
+  trunk:
+    - AdobeMediaSDK
 
 EXTERNAL SOURCES:
   Segment-Adobe-Analytics:
     :path: "../"
 
 SPEC CHECKSUMS:
+  AdobeMediaSDK: 7ee90061503e56f794808e80d4b1ba7e8a0bf4e1
   AdobeMobileSDK: 1d79bf4237c304cab5b7ac8b885146f7abd65261
-  AdobeVideoHeartbeatSDK: e18cf047ae5d995f1762514a66c963dfff60cebf
   Analytics: 2c09a50e3478a3a7ced08a22d00c43ba6f7011e6
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: 706bfbf69a3df55a873bad096014e80e2e8ca93c
   OCMockito: 063837a086c058e764fcd23e771089c1759e7197
-  Segment-Adobe-Analytics: f27d9a8dd939a52df366fc133f2934a5885c6ced
+  Segment-Adobe-Analytics: e21bc3e9463285cc382dc17f406df2620738321b
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882

--- a/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
+++ b/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
@@ -27,10 +27,6 @@
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		956FC58E1FB4D502003028A2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 956FC58D1FB4D502003028A2 /* SystemConfiguration.framework */; };
 		956FC5901FB4D50B003028A2 /* libsqlite3.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 956FC58F1FB4D50B003028A2 /* libsqlite3.0.tbd */; };
-		EA67397D243BB20300F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */; };
-		EA67397E243BB20300F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */; };
-		EA673980243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */; };
-		EA673981243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */; };
 		EAEE78C8242934740071E702 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEE78C7242934740071E702 /* AppDelegate.m */; };
 		EAEE78CB242934740071E702 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEE78CA242934740071E702 /* ViewController.m */; };
 		EAEE78CE242934740071E702 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EAEE78CC242934740071E702 /* Main.storyboard */; };
@@ -101,8 +97,6 @@
 		956FC58F1FB4D50B003028A2 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
 		A7CE40B348129B35230E6116 /* libPods-Segment-Adobe-Analytics_TVOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_TVOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7A0A51A9D07415B1B95EB09 /* Pods-Segment-Adobe-Analytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_Tests/Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = ADBMobileConfig.json; path = ../../../../../../../Downloads/ADBMobileConfig.json; sourceTree = "<group>"; };
-		EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = ADBMobileConfig.json; path = ../../../../../../../Downloads/ADBMobileConfig.json; sourceTree = "<group>"; };
 		EAEE78C4242934740071E702 /* Segment-Adobe-Analytics_TVOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Segment-Adobe-Analytics_TVOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EAEE78C6242934740071E702 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EAEE78C7242934740071E702 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -235,7 +229,6 @@
 		6003F593195388D20070C39A /* Example for Segment-Adobe-Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */,
 				6003F59C195388D20070C39A /* SEGAdobeAppDelegate.h */,
 				6003F59D195388D20070C39A /* SEGAdobeAppDelegate.m */,
 				873B8AEA1B1F5CCA007FD442 /* Main.storyboard */,
@@ -310,7 +303,6 @@
 			isa = PBXGroup;
 			children = (
 				EAEE78C6242934740071E702 /* AppDelegate.h */,
-				EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */,
 				EAEE78C7242934740071E702 /* AppDelegate.m */,
 				EAEE78C9242934740071E702 /* ViewController.h */,
 				EAEE78CA242934740071E702 /* ViewController.m */,
@@ -493,11 +485,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
-				EA673980243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */,
 				71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
 				6003F598195388D20070C39A /* InfoPlist.strings in Resources */,
-				EA67397D243BB20300F6AA49 /* ADBMobileConfig.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -514,10 +504,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEE78D3242934750071E702 /* LaunchScreen.storyboard in Resources */,
-				EA67397E243BB20300F6AA49 /* ADBMobileConfig.json in Resources */,
 				EAEE78D0242934750071E702 /* Assets.xcassets in Resources */,
 				EAEE78CE242934740071E702 /* Main.storyboard in Resources */,
-				EA673981243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
+++ b/Example/Segment-Adobe-Analytics.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1A558AFA1D02C9374645EF30 /* libPods-Segment-Adobe-Analytics_Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */; };
+		20AB739D11DCB0C5790723FE /* libPods-Segment-Adobe-Analytics_TVOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A7CE40B348129B35230E6116 /* libPods-Segment-Adobe-Analytics_TVOS.a */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
 		6003F592195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -26,6 +27,10 @@
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		956FC58E1FB4D502003028A2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 956FC58D1FB4D502003028A2 /* SystemConfiguration.framework */; };
 		956FC5901FB4D50B003028A2 /* libsqlite3.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 956FC58F1FB4D50B003028A2 /* libsqlite3.0.tbd */; };
+		EA67397D243BB20300F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */; };
+		EA67397E243BB20300F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */; };
+		EA673980243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */; };
+		EA673981243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */ = {isa = PBXBuildFile; fileRef = EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */; };
 		EAEE78C8242934740071E702 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEE78C7242934740071E702 /* AppDelegate.m */; };
 		EAEE78CB242934740071E702 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EAEE78CA242934740071E702 /* ViewController.m */; };
 		EAEE78CE242934740071E702 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EAEE78CC242934740071E702 /* Main.storyboard */; };
@@ -63,6 +68,7 @@
 /* Begin PBXFileReference section */
 		03108D42F9B3F734F0E744D9 /* libPods-Segment-Adobe-Analytics_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DFCA7C25AE551722E1AA9A0 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		21B219C5C59858057ED8384D /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_TVOS/Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig"; sourceTree = "<group>"; };
 		3339EE10D97DBF9AF8E1109F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		589428CB55A1F8A3818A9CF5 /* Segment-Adobe-Analytics.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = "Segment-Adobe-Analytics.podspec"; path = "../Segment-Adobe-Analytics.podspec"; sourceTree = "<group>"; };
@@ -88,11 +94,15 @@
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		6E0E12A31FD67EB700279C0B /* libVideoHeartbeat.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libVideoHeartbeat.a; path = ../Pod/libs/libVideoHeartbeat.a; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		780B64A410928E6E45057E09 /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_TVOS/Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		956FC5871FB4D483003028A2 /* ADBMobileConfig.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ADBMobileConfig.json; sourceTree = "<group>"; };
 		956FC58D1FB4D502003028A2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		956FC58F1FB4D50B003028A2 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
+		A7CE40B348129B35230E6116 /* libPods-Segment-Adobe-Analytics_TVOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-Adobe-Analytics_TVOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7A0A51A9D07415B1B95EB09 /* Pods-Segment-Adobe-Analytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Segment-Adobe-Analytics_Tests/Pods-Segment-Adobe-Analytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = ADBMobileConfig.json; path = ../../../../../../../Downloads/ADBMobileConfig.json; sourceTree = "<group>"; };
+		EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = ADBMobileConfig.json; path = ../../../../../../../Downloads/ADBMobileConfig.json; sourceTree = "<group>"; };
 		EAEE78C4242934740071E702 /* Segment-Adobe-Analytics_TVOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Segment-Adobe-Analytics_TVOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		EAEE78C6242934740071E702 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EAEE78C7242934740071E702 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -142,6 +152,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				20AB739D11DCB0C5790723FE /* libPods-Segment-Adobe-Analytics_TVOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +180,8 @@
 				F5AEDAB8513E5B93AFA4DBBB /* Pods-Segment-Adobe-Analytics_Example.release.xcconfig */,
 				5E5F710DF340B64E7CB3BB5D /* Pods-Segment-Adobe-Analytics_Tests.debug.xcconfig */,
 				D7A0A51A9D07415B1B95EB09 /* Pods-Segment-Adobe-Analytics_Tests.release.xcconfig */,
+				780B64A410928E6E45057E09 /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */,
+				21B219C5C59858057ED8384D /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -214,6 +227,7 @@
 				6003F5AF195388D20070C39A /* XCTest.framework */,
 				43B578454AE72BAA6CB34FB6 /* libPods-Segment-Adobe-Analytics_Example.a */,
 				03108D42F9B3F734F0E744D9 /* libPods-Segment-Adobe-Analytics_Tests.a */,
+				A7CE40B348129B35230E6116 /* libPods-Segment-Adobe-Analytics_TVOS.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -221,6 +235,7 @@
 		6003F593195388D20070C39A /* Example for Segment-Adobe-Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				EA67397C243BB20300F6AA49 /* ADBMobileConfig.json */,
 				6003F59C195388D20070C39A /* SEGAdobeAppDelegate.h */,
 				6003F59D195388D20070C39A /* SEGAdobeAppDelegate.m */,
 				873B8AEA1B1F5CCA007FD442 /* Main.storyboard */,
@@ -295,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				EAEE78C6242934740071E702 /* AppDelegate.h */,
+				EA67397F243BB29D00F6AA49 /* ADBMobileConfig.json */,
 				EAEE78C7242934740071E702 /* AppDelegate.m */,
 				EAEE78C9242934740071E702 /* ViewController.h */,
 				EAEE78CA242934740071E702 /* ViewController.m */,
@@ -369,6 +385,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAEE78F3242934750071E702 /* Build configuration list for PBXNativeTarget "Segment-Adobe-Analytics_TVOS" */;
 			buildPhases = (
+				FEFD0CBAC3370C5E9D81E6CB /* [CP] Check Pods Manifest.lock */,
 				EAEE78C0242934740071E702 /* Sources */,
 				EAEE78C1242934740071E702 /* Frameworks */,
 				EAEE78C2242934740071E702 /* Resources */,
@@ -476,9 +493,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
+				EA673980243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */,
 				71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
 				6003F598195388D20070C39A /* InfoPlist.strings in Resources */,
+				EA67397D243BB20300F6AA49 /* ADBMobileConfig.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,8 +514,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				EAEE78D3242934750071E702 /* LaunchScreen.storyboard in Resources */,
+				EA67397E243BB20300F6AA49 /* ADBMobileConfig.json in Resources */,
 				EAEE78D0242934750071E702 /* Assets.xcassets in Resources */,
 				EAEE78CE242934740071E702 /* Main.storyboard in Resources */,
+				EA673981243BB29D00F6AA49 /* ADBMobileConfig.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -547,6 +568,28 @@
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-Segment-Adobe-Analytics_Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FEFD0CBAC3370C5E9D81E6CB /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Segment-Adobe-Analytics_TVOS-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -828,6 +871,7 @@
 		};
 		EAEE78ED242934750071E702 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 780B64A410928E6E45057E09 /* Pods-Segment-Adobe-Analytics_TVOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -866,6 +910,7 @@
 		};
 		EAEE78EE242934750071E702 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 21B219C5C59858057ED8384D /* Pods-Segment-Adobe-Analytics_TVOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
+++ b/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
@@ -20,7 +20,18 @@
 
   [config use:[SEGAdobeIntegrationFactory instance]];
   [SEGAnalytics setupWithConfiguration:config];
-  [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+  [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"
+                            properties:@{
+                                @"channel": @"SegTest",
+                                @"video_player": @"Segment",
+                                @"title": @"Test Show",
+                                @"content_asset_id": @"132421",
+                                @"total_length": @"300",
+                                @"livestream": @false,
+                            }
+                             options:@{
+                                @"context":@{}}
+  ];
   [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
                          properties: @{ @"full_episode": @true }
                             options: @{

--- a/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
+++ b/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
@@ -24,12 +24,23 @@
 
     [config use:[SEGAdobeIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:config];
-    [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"];
+    [[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"
+                              properties:@{
+                                  @"channel": @"SegTest",
+                                  @"video_player": @"Segment",
+                                  @"title": @"Test Show",
+                                  @"content_asset_id": @"132421",
+                                  @"total_length": @"300",
+                                  @"livestream": @false,
+                              }
+                               options:@{
+                                  @"context":@{}}
+    ];
     [[SEGAnalytics sharedAnalytics] track:@"Video Content Started"
-                               properties: @{ @"full_episode": @true }
-                                  options: @{
-                                      @"integrations": @{}
-                                  }];
+                           properties: @{ @"full_episode": @true }
+                              options: @{
+                                @"integrations": @{}
+                            }];
 
     [[SEGAnalytics sharedAnalytics] flush];
     [SEGAnalytics debug:YES];

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -10,8 +10,8 @@
 #import <Analytics/SEGIntegration.h>
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGAnalytics.h>
-#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeat.h>
-#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeatConfig.h>
+#import <AdobeMediaSDK/ADBMediaHeartbeatConfig.h>
+#import <AdobeMediaSDK/ADBMediaHeartbeat.h>
 
 @interface SEGPlaybackDelegate(Private)<ADBMediaHeartbeatDelegate>
 @end
@@ -222,9 +222,9 @@
 
 - (void)reset
 {
-   #if !TARGET_OS_TV
-        [self.adobeMobile trackingClearCurrentBeacon];
-        SEGLog(@"[ADBMobile trackingClearCurrentBeacon];");
+    #if !TARGET_OS_WATCH && !TARGET_OS_TV
+    [self.adobeMobile trackingClearCurrentBeacon];
+    SEGLog(@"[ADBMobile trackingClearCurrentBeacon];");
     #endif
 }
 

--- a/Pod/Classes/SEGAdobeIntegrationFactory.m
+++ b/Pod/Classes/SEGAdobeIntegrationFactory.m
@@ -1,6 +1,6 @@
 #import "SEGAdobeIntegrationFactory.h"
 #import "SEGAdobeIntegration.h"
-#import <AdobeVideoHeartbeatSDK/ADBMediaHeartbeatConfig.h>
+#import <AdobeMediaSDK/ADBMediaHeartbeatConfig.h>
 
 
 @implementation SEGAdobeIntegrationFactory

--- a/Segment-Adobe-Analytics.podspec
+++ b/Segment-Adobe-Analytics.podspec
@@ -22,9 +22,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'Analytics', '~> 3.5'
   s.ios.dependency 'AdobeMobileSDK'
-  s.ios.dependency 'AdobeVideoHeartbeatSDK'
   s.tvos.dependency 'AdobeMobileSDK/TVOS'
-  s.tvos.dependency 'AdobeVideoHeartbeatSDK/TVOS'
+  s.dependency 'AdobeMediaSDK'
 
   s.static_framework = true
   s.module_name      = 'Segment_Adobe_Analytics'


### PR DESCRIPTION
Adobe's VideoHeartbeatSDK has been deprecated in favor of AdobeMediaSDK. Using the old SDK for iOS tvOS was resulting in issues where only a `Video Content Stated` event was being fired and no ping events were being sent. 

I confirmed that post-upgrading this dependency all events and pings are firing on tvOS and iOS. '

I also updated the cocoapods version. on Circle CI as newer versions of cocopods now references   CDN support for the trunk specs repo.