### PR TITLE
[STRATCONN-222] Add Support  for Video Interruptted

### DIFF
--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -640,7 +640,6 @@ describe(@"SEGAdobeIntegration", ^{
 
                 [integration track:payload];
                 [verify(mockPlaybackDelegate) pausePlayhead];
-                [verify(mockADBMediaHeartbeat) trackPause];
             });
 
             it(@"track Video Playback Buffer Started", ^{

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -620,6 +620,29 @@ describe(@"SEGAdobeIntegration", ^{
                 [verify(mockADBMediaHeartbeat) trackPause];
             });
 
+            it(@"track Video Playback Interrupted", ^{
+                SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
+                mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;
+
+                SEGMockADBMediaObjectFactory *mockADBMediaObjectFactory = [[SEGMockADBMediaObjectFactory alloc] init];
+                mockADBMediaObjectFactory.mediaObject = mockADBMediaObject;
+
+                SEGTrackPayload *payload = [[SEGTrackPayload alloc] initWithEvent:@"Video Playback Interrupted" properties:@{
+                    @"content_asset_id" : @"7890",
+                    @"ad_type" : @"mid-roll",
+                    @"video_player" : @"vimeo",
+                    @"position" : @30,
+                    @"sound" : @100,
+                    @"full_screen" : @YES,
+                    @"bitrate" : @50
+                } context:@{}
+                    integrations:@{}];
+
+                [integration track:payload];
+                [verify(mockPlaybackDelegate) pausePlayhead];
+                [verify(mockADBMediaHeartbeat) trackPause];
+            });
+
             it(@"track Video Playback Buffer Started", ^{
                 SEGMockADBMediaHeartbeatFactory *mockADBMediaHeartbeatFactory = [[SEGMockADBMediaHeartbeatFactory alloc] init];
                 mockADBMediaHeartbeatFactory.mediaHeartbeat = mockADBMediaHeartbeat;

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -269,6 +269,7 @@
     NSArray *adobeVideoEvents = @[
         @"Video Playback Started",
         @"Video Playback Paused",
+        @"Video Playback Interrupted",
         @"Video Playback Buffer Started",
         @"Video Playback Buffer Completed",
         @"Video Playback Seek Started",
@@ -546,6 +547,13 @@
     }
 
     if ([payload.event isEqualToString:@"Video Playback Paused"]) {
+        [self.playbackDelegate pausePlayhead];
+        [self.mediaHeartbeat trackPause];
+        SEGLog(@"[ADBMediaHeartbeat trackPause]");
+        return;
+    }
+
+    if ([payload.event isEqualToString:@"Video Playback Interrupted"]) {
         [self.playbackDelegate pausePlayhead];
         [self.mediaHeartbeat trackPause];
         SEGLog(@"[ADBMediaHeartbeat trackPause]");

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -553,12 +553,6 @@
         return;
     }
 
-    if ([payload.event isEqualToString:@"Video Playback Interrupted"]) {
-        [self.playbackDelegate pausePlayhead];
-        [self.mediaHeartbeat trackPause];
-        SEGLog(@"[ADBMediaHeartbeat trackPause]");
-        return;
-    }
 
     if ([payload.event isEqualToString:@"Video Playback Resumed"]) {
         [self.playbackDelegate unPausePlayhead];


### PR DESCRIPTION
Android and Web AA  integrations support Video Interrupted events which maps to a `pausePlayhead` and a `trackPause`. To maintain parity with our other components we are adding support for Video Interrupted to our iOS SDK. 

A PR was submitted by customer but did  not implement any functional changes and did not implement unit tests. 

JIRA: https://segment.atlassian.net/browse/STRATCONN-222