### PR TITLE
[STRATCONN-266] Update Boolean & Track Complete Logic

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,20 +2,20 @@ PODS:
   - AdobeMediaSDK (2.2.7):
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
-  - AdobeMobileSDK (4.18.7):
-    - AdobeMobileSDK/iOS (= 4.18.7)
-  - AdobeMobileSDK/iOS (4.18.7)
-  - AdobeMobileSDK/TVOS (4.19.1)
-  - Analytics (3.6.7)
+  - AdobeMobileSDK (4.19.2):
+    - AdobeMobileSDK/iOS (= 4.19.2)
+  - AdobeMobileSDK/iOS (4.19.2)
+  - AdobeMobileSDK/TVOS (4.19.2)
+  - Analytics (4.0.1)
   - Expecta (1.0.6)
-  - OCHamcrest (7.0.2)
-  - OCMockito (5.0.1):
+  - OCHamcrest (7.1.2)
+  - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.4.3):
+  - Segment-Adobe-Analytics (1.5.2):
     - AdobeMediaSDK
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
-    - Analytics (~> 3.5)
+    - Analytics
   - Specta (1.0.7)
 
 DEPENDENCIES:
@@ -25,15 +25,14 @@ DEPENDENCIES:
   - Specta
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
+    - AdobeMediaSDK
     - AdobeMobileSDK
     - Analytics
     - Expecta
     - OCHamcrest
     - OCMockito
     - Specta
-  trunk:
-    - AdobeMediaSDK
 
 EXTERNAL SOURCES:
   Segment-Adobe-Analytics:
@@ -41,12 +40,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AdobeMediaSDK: 7ee90061503e56f794808e80d4b1ba7e8a0bf4e1
-  AdobeMobileSDK: 1d79bf4237c304cab5b7ac8b885146f7abd65261
-  Analytics: 2c09a50e3478a3a7ced08a22d00c43ba6f7011e6
+  AdobeMobileSDK: 94f32d06c18ff363eee1c5486e73c741c4cd3865
+  Analytics: ebdc0c3ed93684d10c898f57886e0ce7fbecc240
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
-  OCHamcrest: 706bfbf69a3df55a873bad096014e80e2e8ca93c
-  OCMockito: 063837a086c058e764fcd23e771089c1759e7197
-  Segment-Adobe-Analytics: e21bc3e9463285cc382dc17f406df2620738321b
+  OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
+  OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
+  Segment-Adobe-Analytics: ba8df8bd3729935b4ce1472181f2e35dc4253069
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - AdobeMobileSDK/iOS (= 4.19.2)
   - AdobeMobileSDK/iOS (4.19.2)
   - AdobeMobileSDK/TVOS (4.19.2)
-  - Analytics (4.0.1)
+  - Analytics (4.0.2)
   - Expecta (1.0.6)
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
@@ -41,7 +41,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AdobeMediaSDK: 7ee90061503e56f794808e80d4b1ba7e8a0bf4e1
   AdobeMobileSDK: 94f32d06c18ff363eee1c5486e73c741c4cd3865
-  Analytics: ebdc0c3ed93684d10c898f57886e0ce7fbecc240
+  Analytics: 8eb3f744811eabd5eb94d50de1bd33c0369f10ab
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -218,11 +218,11 @@ describe(@"SEGAdobeIntegration", ^{
                                                   andMediaObjectFactory:nil
                                              andPlaybackDelegateFactory:nil];
 
-            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @YES }
+            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @true }
                 context:@{}
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @YES }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"true" }];
         });
 
         it(@"tracks a screen state with context fields configured in settings.contextValues", ^{
@@ -235,10 +235,10 @@ describe(@"SEGAdobeIntegration", ^{
                                              andPlaybackDelegateFactory:nil];
 
             SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{}
-                context:@{ @"new_user" : @YES }
+                context:@{ @"new_user" : @false }
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @YES }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"false" }];
         });
     });
 
@@ -787,6 +787,7 @@ describe(@"SEGAdobeIntegration", ^{
 
                 [integration track:payload];
                 [verify(mockPlaybackDelegate) pausePlayhead];
+                [verify(mockADBMediaHeartbeat) trackComplete];
                 [verify(mockADBMediaHeartbeat) trackSessionEnd];
             });
 
@@ -879,7 +880,6 @@ describe(@"SEGAdobeIntegration", ^{
                     integrations:@{}];
 
                 [integration track:payload];
-                [verify(mockADBMediaHeartbeat) trackComplete];
                 [verify(mockADBMediaHeartbeat) trackEvent:ADBMediaHeartbeatEventChapterComplete mediaObject:nil data:nil];
             });
         });

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone SE"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
 PROJECT := Segment-Adobe-Analytics
 XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 SDK ?= "iphonesimulator"
-DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
+DESTINATION ?= "platform=iOS Simulator,name=iPhone SE"
 PROJECT := Segment-Adobe-Analytics
 XC_ARGS := -scheme $(PROJECT)_Example -workspace Example/$(PROJECT).xcworkspace -sdk $(SDK) -destination $(DESTINATION) ONLY_ACTIVE_ARCH=NO
 

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -571,6 +571,8 @@
 
     if ([payload.event isEqualToString:@"Video Playback Completed"]) {
         [self.playbackDelegate pausePlayhead];
+        [self.mediaHeartbeat trackComplete];
+        SEGLog(@"[ADBMediaHeartbeat trackComplete]");
         [self.mediaHeartbeat trackSessionEnd];
         SEGLog(@"[ADBMediaHeartbeat trackSessionEnd]");
         return;
@@ -587,9 +589,6 @@
     }
 
     if ([payload.event isEqualToString:@"Video Content Completed"]) {
-        [self.mediaHeartbeat trackComplete];
-        SEGLog(@"[ADBMediaHeartbeat trackComplete]");
-
         self.mediaObject = [self createMediaObject:payload.properties andEventType:@"Content"];
 
         // Adobe examples show that the mediaObject and data should be nil on Chapter Complete events

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -323,7 +323,6 @@
  @param  context  Segment payload.context
  @return data Dictionary of context data with Adobe key
 **/
-
 - (NSMutableDictionary *)mapContextValues:(NSDictionary *)properties context:(NSDictionary *)context
 {
     NSInteger contextValuesSize = [self.settings[@"contextValues"] count];
@@ -339,11 +338,20 @@
                     [data setObject:contextTraits[parsedKey] forKey:contextValues[key]];
                 }
             }
+            NSDictionary *payloadLocation;
             if (properties[key]) {
-                [data setObject:properties[key] forKey:contextValues[key]];
+                payloadLocation = [NSDictionary dictionaryWithDictionary:properties];
+            } if (context[key]) {
+                payloadLocation = [NSDictionary dictionaryWithDictionary:context];
             }
-            if (context[key]) {
-              [data setObject:context[key] forKey:contextValues[key]];
+            if (payloadLocation) {
+                if ([payloadLocation[key] isEqual:@YES]) {
+                    [data setObject:@"true" forKey:contextValues[key]];
+                } else if ([payloadLocation[key] isEqual:@NO]){
+                    [data setObject:@"false" forKey:contextValues[key]];
+                } else {
+                    [data setObject:payloadLocation[key] forKey:contextValues[key]];
+                }
             }
         }
         return data;

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -386,8 +386,7 @@
     NSMutableDictionary *topLevelProperties = [[NSMutableDictionary alloc] initWithCapacity:10];
     [topLevelProperties setValue:payload.messageId forKey:@"messageId"];
     [topLevelProperties setValue:payload.event forKey:@"event"];
-    // TODO: implement post bump of iOS-anaytics core SDK
-//    [topLevelProperties setValue:payload.event forKey:@"anonymousId"];
+    [topLevelProperties setValue:payload.anonymousId forKey:@"anonymousId"];
     return topLevelProperties;
 }
 
@@ -396,8 +395,7 @@
     NSMutableDictionary *topLevelProperties = [[NSMutableDictionary alloc] initWithCapacity:10];
     [topLevelProperties setValue:payload.messageId forKey:@"messageId"];
     [topLevelProperties setValue:payload.name forKey:@"name"];
-    // TODO: implement post bump of iOS-anaytics core SDK
-//    [topLevelProperties setValue:payload.event forKey:@"anonymousId"];
+    [topLevelProperties setValue:payload.anonymousId forKey:@"anonymousId"];
     return topLevelProperties;
 }
 


### PR DESCRIPTION
JIRA Tickets:
[STRATCONN-266](https://segment.atlassian.net/browse/STRATCONN-266)
[STRATCONN-271](https://segment.atlassian.net/browse/STRATCONN-271)
[STRATCONN-212](https://segment.atlassian.net/browse/STRATCONN-212)

## What it does
1. If a customer is passing a boolean value on a payload property that is to be sent to Adobe as either a context data variable to custom video metadata instead of passing as a `0` or `1` we will use  string  version of `"true"` or `"false"`
2. Removes trackComplete from Video Content Completed events  as it incorrectly ends the  session and discards subsequent HB calls. 
3. Adds trackComplete to Video Playback Completed events per Adobe  documentation, before calling sessionEnd
4. Adds support to map top level properties on track calls (messageId, anonymousId, event) and on  screen (name, messageId and anonymousId) NOTE: need to  uncomment anonymousId  before merging and bump analytics-iOS version once LIB team publishes their updates 
5. Adds support for nested context data (non-HB) variable and context metadata (HB) mapping in context.app, context.device, context.library, os,  network, and screen. Customers can follow the following format for Context Data Variable Mapping: 
<img width="691" alt="Screen Shot 2020-06-24 at 9 03 10 PM" src="https://user-images.githubusercontent.com/31782219/85651957-3c1dfa00-b65e-11ea-836c-b1a3c0bc92cb.png">
5. Updates unit tests 

