### PR TITLE
[STRATCONN-286] Remove stringified booleans context variables

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.5.2):
+  - Segment-Adobe-Analytics (1.6.0):
     - AdobeMediaSDK
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
-  Segment-Adobe-Analytics: ba8df8bd3729935b4ce1472181f2e35dc4253069
+  Segment-Adobe-Analytics: ea27255fa72d13277f66c0c500f2fae0174578bd
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -218,11 +218,11 @@ describe(@"SEGAdobeIntegration", ^{
                                                   andMediaObjectFactory:nil
                                              andPlaybackDelegateFactory:nil];
 
-            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @true }
+            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @true, @"title": @1 }
                 context:@{}
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"true" }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @true, @"myapp.title": @1 }];
         });
 
         it(@"tracks a screen state with context fields configured in settings.contextValues", ^{
@@ -238,7 +238,7 @@ describe(@"SEGAdobeIntegration", ^{
                 context:@{ @"new_user" : @false }
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"false" }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @false }];
         });
     });
 

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -357,16 +357,8 @@
                 payloadLocation = [NSDictionary dictionaryWithDictionary:context];
             }
         
-            // If the value of the key is a boolean we convert to string "true"/"false" rather than 0/1 values Obj-C will convert it to
-            // All non-boolean data types we simply assign to the data object
             if (payloadLocation) {
-                if ([payloadLocation[key] isEqual:@YES]) {
-                    [data setObject:@"true" forKey:contextValues[key]];
-                } else if ([payloadLocation[key] isEqual:@NO]){
-                    [data setObject:@"false" forKey:contextValues[key]];
-                } else {
-                    [data setObject:payloadLocation[key] forKey:contextValues[key]];
-                }
+                [data setObject:payloadLocation[key] forKey:contextValues[key]];
             }
             
             // For screen and track calls our core analytics-ios lib exposes these top level properties


### PR DESCRIPTION
STRATCONN-286: https://segment.atlassian.net/browse/STRATCONN-286

Remove logic introduced in Segment-Adobe-Analytics v1.6.0 to stringify booleans. This introduced a bug that converts integers 0/1 to boolean values  "true"/"false". 

NOTE: Recieved sign-off to merge from DSJ on 7/1/2020 since mobile is  not part of code freeze.