### PR TITLE
Support for stringified booleans

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.6.0):
+  - Segment-Adobe-Analytics (1.6.1):
     - AdobeMediaSDK
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
-  Segment-Adobe-Analytics: ea27255fa72d13277f66c0c500f2fae0174578bd
+  Segment-Adobe-Analytics: 86abb3557e0a2df7a143abfad5d1915cfcf5f312
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -218,11 +218,11 @@ describe(@"SEGAdobeIntegration", ^{
                                                   andMediaObjectFactory:nil
                                              andPlaybackDelegateFactory:nil];
 
-            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @true, @"title": @1 }
+            SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{ @"new_user" : @YES, @"title": @1 }
                 context:@{}
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @true, @"myapp.title": @1 }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"true", @"myapp.title": @1 }];
         });
 
         it(@"tracks a screen state with context fields configured in settings.contextValues", ^{
@@ -235,10 +235,10 @@ describe(@"SEGAdobeIntegration", ^{
                                              andPlaybackDelegateFactory:nil];
 
             SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"Sign Up" properties:@{}
-                context:@{ @"new_user" : @false }
+                context:@{ @"new_user" : @NO }
                 integrations:@{}];
             [integration screen:screenPayload];
-            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @false }];
+            [verify(mockADBMobile) trackState:@"Sign Up" data:@{ @"myapp.new_user" : @"false" }];
         });
     });
 

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -311,6 +311,14 @@
     SEGLog(@"[ADBMobile trackState:%@ data:%@];", payload.name, data);
 }
 
+BOOL isBoolean(NSObject* object)
+{
+    CFTypeID boolTypeID = CFBooleanGetTypeID();
+    //the type ID of CFBoolean
+    CFTypeID objectTypeID = CFGetTypeID((__bridge CFTypeRef)(object));
+    //the type ID of num
+    return objectTypeID == boolTypeID;
+}
 ///-------------------------
 /// @name Mapping
 ///-------------------------
@@ -328,7 +336,6 @@
 **/
 - (NSMutableDictionary *)mapContextValues:(NSDictionary *)properties andContext:(NSDictionary *)context withTopLevelProps:(NSMutableDictionary *)topLevelProps
 {
- 
     NSInteger contextValuesSize = [self.settings[@"contextValues"] count];
     if (([properties count] > 0 || [context count] > 0) && contextValuesSize > 0) {
         NSMutableDictionary *data = [[NSMutableDictionary alloc] initWithCapacity:contextValuesSize];
@@ -356,11 +363,17 @@
             if (context[key]) {
                 payloadLocation = [NSDictionary dictionaryWithDictionary:context];
             }
-        
+
             if (payloadLocation) {
-                [data setObject:payloadLocation[key] forKey:contextValues[key]];
+                if (isBoolean(payloadLocation[key])  &&  [payloadLocation[key] isEqual:@YES]){
+                   [data setObject:@"true" forKey:contextValues[key]];
+                } else if (isBoolean(payloadLocation[key])  &&  [payloadLocation[key] isEqual:@NO]){
+                     [data setObject:@"false" forKey:contextValues[key]];
+                } else {
+                    [data setObject:payloadLocation[key] forKey:contextValues[key]];
+                }
             }
-            
+
             // For screen and track calls our core analytics-ios lib exposes these top level properties
             // These properties are extractetd from the  payload using helper methods (extractSEGTrackTopLevelProps & extractSEGScreenTopLevelProps)
             NSArray *topLevelProperties = @[@"event", @"messageId", @"anonymousId", @"name"];


### PR DESCRIPTION
CC Ticket for deployment during code freeze/HW: https://segment.atlassian.net/browse/CC-6671

* Adds back support for stringified booleans
* Ensure this was working in charles proxy and ensured  no negative side effect on integers being passed as 0/1 

The following was  tested with this test event using contextValues from this [Source](https://app.segment.com/brienne-mcnally/destinations/adobe-analytics/sources/ios_adjust_test/configuration)
```
[[SEGAnalytics sharedAnalytics] track:@"Video Playback Started"
                            properties:@{
                                @"channel": @"SegTest",
                                @"video_player": @"Segment",
                                @"title": @"Test Show",
                                @"content_asset_id": @"132421",
                                @"total_length": @"300",
                                @"livestream": @false,
                            }
                             options:@{
                                 @"context":@{ @"video_genre": @NO, @"primary_business_unit": @1 }}
```

True Test: 
![Screen Shot 2020-07-02 at 9 38 04 AM](https://user-images.githubusercontent.com/31782219/86387754-84ce4800-bc48-11ea-8f9b-b2797db431d2.png)



False Test: 
![Screen Shot 2020-07-02 at 9 38 48 AM](https://user-images.githubusercontent.com/31782219/86387769-88fa6580-bc48-11ea-81eb-d9e880fa79b3.png)
