### PR TITLE
update streamType mapping to correctly reference livestream boolean value

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - OCHamcrest (7.1.2)
   - OCMockito (5.1.3):
     - OCHamcrest (~> 7.0)
-  - Segment-Adobe-Analytics (1.6.1):
+  - Segment-Adobe-Analytics (1.6.2):
     - AdobeMediaSDK
     - AdobeMobileSDK
     - AdobeMobileSDK/TVOS
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   OCHamcrest: b284c9592c28c1e4025a8542e67ea41a635d0d73
   OCMockito: 677cbb4a18fd492b5a4fb10144dada4de5ddb877
-  Segment-Adobe-Analytics: 86abb3557e0a2df7a143abfad5d1915cfcf5f312
+  Segment-Adobe-Analytics: 67a15fb849ac3359764675502f7673bb3b0267da
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
 
 PODFILE CHECKSUM: 599db44d427d9aeea39e5c49c1b55ab56fb6a882

--- a/Example/Segment-Adobe-Analytics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Segment-Adobe-Analytics.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Segment-Adobe-Analytics.xcodeproj/xcshareddata/xcschemes/Segment-Adobe-Analytics_Example.xcscheme
+++ b/Example/Segment-Adobe-Analytics.xcodeproj/xcshareddata/xcschemes/Segment-Adobe-Analytics_Example.xcscheme
@@ -26,9 +26,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6003F589195388D20070C39A"
+            BuildableName = "Segment-Adobe-Analytics_Example.app"
+            BlueprintName = "Segment-Adobe-Analytics_Example"
+            ReferencedContainer = "container:Segment-Adobe-Analytics.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -41,23 +49,11 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6003F589195388D20070C39A"
-            BuildableName = "Segment-Adobe-Analytics_Example.app"
-            BlueprintName = "Segment-Adobe-Analytics_Example"
-            ReferencedContainer = "container:Segment-Adobe-Analytics.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -74,8 +70,6 @@
             ReferencedContainer = "container:Segment-Adobe-Analytics.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Segment-Adobe-Analytics.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Segment-Adobe-Analytics.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -611,7 +611,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @30,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @NO
                 } context:@{}
                     integrations:@{}];
 
@@ -634,7 +635,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @30,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @NO
                 } context:@{}
                     integrations:@{}];
 
@@ -657,8 +659,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @190,
                     @"sound" : @100,
                     @"full_screen" : @NO,
-                    @"bitrate" : @50
-
+                    @"bitrate" : @50,
+                    @"livestream" : @NO
                 } context:@{}
                     integrations:@{}];
 
@@ -681,7 +683,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @90,
                     @"sound" : @100,
                     @"full_screen" : @NO,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @YES
 
                 } context:@{}
                     integrations:@{}];
@@ -706,7 +709,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"seek_position" : @20,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @YES
 
                 } context:@{}
                     integrations:@{}];
@@ -731,7 +735,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @20,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @YES
 
                 } context:@{}
                     integrations:@{}];
@@ -756,7 +761,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @34,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @YES
 
                 } context:@{}
                     integrations:@{}];
@@ -780,7 +786,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @30,
                     @"sound" : @100,
                     @"full_screen" : @YES,
-                    @"bitrate" : @50
+                    @"bitrate" : @50,
+                    @"livestream" : @NO
                 }
                     context:@{}
                     integrations:@{}];
@@ -821,7 +828,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @22,
                     @"channel" : @"Cartoon Network",
                     @"start_time" : @140,
-                    @"position" : @5
+                    @"position" : @5,
+                    @"livestream" : @NO
                 } context:@{}
                     integrations:@{}];
                 [integration track:payload];
@@ -849,7 +857,8 @@ describe(@"SEGAdobeIntegration", ^{
                     @"position" : @22,
                     @"channel" : @"Cartoon Network",
                     @"start_time" : @140,
-                    @"position" : @5
+                    @"position" : @5,
+                    @"livestream" : @NO
                 } context:@{}
                     integrations:@{}];
                 [integration track:payload];
@@ -873,9 +882,10 @@ describe(@"SEGAdobeIntegration", ^{
                     @"genre" : @"cartoon",
                     @"program" : @"Rick and Morty",
                     @"total_length" : @400,
-                    @"full_episode" : @"true",
+                    @"full_episode" : @YES,
                     @"publisher" : @"Turner Broadcasting Network",
-                    @"channel" : @"Cartoon Network"
+                    @"channel" : @"Cartoon Network",
+                    @"livestream" : @YES
                 } context:@{}
                     integrations:@{}];
 

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -168,7 +168,7 @@
 
     // Adobe also has a third type: linear, which we have chosen
     // to omit as it does not conform to Segment's Video spec
-    bool isLivestream = properties[@"livestream"];
+    bool isLivestream = [properties[@"livestream"] boolValue];
     NSString *streamType = ADBMediaHeartbeatStreamTypeVOD;
     if (isLivestream) {
         streamType = ADBMediaHeartbeatStreamTypeLIVE;


### PR DESCRIPTION
Fox is seeing the Adobe `streamType` variable always set to “live” even when livestream = false (it should be “vod” in these cases). However, the Adobe `STREAM_FORMAT` variable is correctly set to “vod” when livestream = true. I have replicated the behavior and see that even when livestream = false, the `streamType` is labeled "live" in the network calls to Adobe.

In our integration code, we do basically the same mapping to each variable. The only difference is:

STREAM_FORMAT references `bool isLivestream = [properties[@"livestream"] boolValue];`
streamType references `bool isLivestream = properties[@"livestream"];`

@gpsamson confirmed that leaving out `boolValue` is causing our integration to not actually check the true/false value for streamType and therefore setting all events that have the livestream property to “live”.  I have updated our integration so that streamType uses `bool isLivestream = properties[@"livestream" boolValue];` instead. I have also updated the Tests to include the livestream property on playback and content events. All unit tests passed!

Unit test results:
![Screen Shot 2020-09-09 at 4 08 48 PM](https://user-images.githubusercontent.com/49517136/92663991-a5092b80-f2b7-11ea-8a61-3bf8dcfcf743.png)