### PR TITLE
[STRATCONN-419] Update namespacing for ios14

### DIFF
--- a/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
+++ b/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
@@ -8,8 +8,11 @@
 
 #import "SEGAdobeAppDelegate.h"
 #import "SEGAdobeIntegrationFactory.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
-
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
 
 
 @implementation SEGAdobeAppDelegate

--- a/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
+++ b/Example/Segment-Adobe-Analytics/SEGAdobeAppDelegate.m
@@ -8,7 +8,7 @@
 
 #import "SEGAdobeAppDelegate.h"
 #import "SEGAdobeIntegrationFactory.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>

--- a/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
+++ b/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
@@ -8,7 +8,7 @@
 
 #import "AppDelegate.h"
 #import "SEGAdobeIntegrationFactory.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
 #else
 #import <Segment/SEGAnalytics.h>

--- a/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
+++ b/Example/Segment-Adobe-Analytics_TVOS/AppDelegate.m
@@ -8,8 +8,11 @@
 
 #import "AppDelegate.h"
 #import "SEGAdobeIntegrationFactory.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGAnalytics.h>
-
+#else
+#import <Segment/SEGAnalytics.h>
+#endif
 
 @interface AppDelegate ()
 

--- a/Pod/Classes/SEGAdobeIntegration.h
+++ b/Pod/Classes/SEGAdobeIntegration.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #else
 #import <Segment/SEGIntegration.h>

--- a/Pod/Classes/SEGAdobeIntegration.h
+++ b/Pod/Classes/SEGAdobeIntegration.h
@@ -7,7 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
+#else
+#import <Segment/SEGIntegration.h>
+#endif
 #import <AdobeMobileSDK/ADBMobile.h>
 
 @class ADBMediaHeartbeat;

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -7,7 +7,7 @@
 //
 
 #import "SEGAdobeIntegration.h"
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegration.h>
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGAnalytics.h>

--- a/Pod/Classes/SEGAdobeIntegration.m
+++ b/Pod/Classes/SEGAdobeIntegration.m
@@ -7,9 +7,16 @@
 //
 
 #import "SEGAdobeIntegration.h"
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegration.h>
 #import <Analytics/SEGAnalyticsUtils.h>
 #import <Analytics/SEGAnalytics.h>
+#else
+#import <Segment/SEGIntegration.h>
+#import <Segment/SEGAnalyticsUtils.h>
+#import <Segment/SEGAnalytics.h>
+#endif
+
 #import <AdobeMediaSDK/ADBMediaHeartbeatConfig.h>
 #import <AdobeMediaSDK/ADBMediaHeartbeat.h>
 

--- a/Pod/Classes/SEGAdobeIntegrationFactory.h
+++ b/Pod/Classes/SEGAdobeIntegrationFactory.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
 #else
 #import <Segment/SEGIntegrationFactory.h>

--- a/Pod/Classes/SEGAdobeIntegrationFactory.h
+++ b/Pod/Classes/SEGAdobeIntegrationFactory.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
+#if defined(__has_include) && __has_include(<Analytics/Analytics.h>)
 #import <Analytics/SEGIntegrationFactory.h>
-
+#else
+#import <Segment/SEGIntegrationFactory.h>
+#endif
 
 @interface SEGAdobeIntegrationFactory : NSObject <SEGIntegrationFactory>
 


### PR DESCRIPTION
https://paper.dropbox.com/doc/PRD-Analytics-iOS-Namespace-Change--A89lGjxWJiMUgRtRmVL5aN1UAg-FewzU7P1dJM5yKVEgfenA

Segment’s iOS SDK was namespaced to SEGAnalytics under the Objective-C naming convention. As we modernized the SDK to support Swift and more package managers beyond Cocoapods such as Swift Package Manager and Carthage the namespace was renamed to Analytics in-line with Swift idioms as well as Package Manager requirements. It was released as beta. We have received customer feedback that this is leading to namespace collisions and are now going to change this to a much clearer namespace: Segment and the community prefer this as well.